### PR TITLE
Typo fixed. Beat to beats

### DIFF
--- a/src/components/InfoPanel3/index.tsx
+++ b/src/components/InfoPanel3/index.tsx
@@ -6,7 +6,7 @@ export default function InfoPanel1() {
   return (
     <Row gutter={0} className={styles.row}>
       <Col span={12}>
-        <h1 className={styles.header1}>Collect royalties on your beat <em>forever</em>.</h1>
+        <h1 className={styles.header1}>Collect royalties on your beats <em>forever</em>.</h1>
         <p className={styles.paragraph1}>When an artist licenses your beat through Sweatshop Beats, you are entitled to 3%-5% royalties <em>forever</em>.</p>
       </Col>
       <Col span={12}>


### PR DESCRIPTION
Splash page typo. On 3rd infopanel, just changed the word "beat" to "beats" per Tana's request. Wouldn't normally put in a pull request for something this simple, but it's the home page and Tana wanted it fixed.