### PR TITLE
reformatted splash page for mobile

### DIFF
--- a/src/components/InfoPanel1/Infopanel1.module.css
+++ b/src/components/InfoPanel1/Infopanel1.module.css
@@ -1,3 +1,7 @@
+/* Desktop CSS */
+
+@media (min-width: 480px) {
+
 .row {
   background-color: black;
   color: white;
@@ -26,4 +30,15 @@
   width: 30vw;
   height: auto;
   padding-top: 16vh;
+}
+
+}
+
+/* Mobile CSS */
+
+@media (max-width: 480px) {
+
+  .row {
+    display: none;
+  }
 }

--- a/src/components/InfoPanel2/Infopanel2.module.css
+++ b/src/components/InfoPanel2/Infopanel2.module.css
@@ -1,3 +1,7 @@
+/* Desktop CSS */
+
+@media (min-width: 480px) {
+
 .row {
   width: 100vw;
   height: 110vh;
@@ -22,4 +26,15 @@
   width: 28vw;
   height: auto;
   padding-top: 25vh;
+}
+
+}
+
+/* Mobile CSS */
+
+@media (max-width: 480px) {
+
+  .row {
+    display: none;
+  }
 }

--- a/src/components/InfoPanel3/Infopanel3.module.css
+++ b/src/components/InfoPanel3/Infopanel3.module.css
@@ -1,3 +1,7 @@
+/* Desktop CSS */
+
+@media (min-width: 480px) {
+
 .row {
   background-color: black;
   color: white;
@@ -26,4 +30,15 @@
   width: 28vw;
   height: auto;
   padding-top: 22vh;
+}
+
+}
+
+/* Mobile CSS */
+
+@media (max-width: 480px) {
+
+  .row {
+    display: none;
+  }
 }

--- a/src/components/pages/Splash/Splash.module.css
+++ b/src/components/pages/Splash/Splash.module.css
@@ -1,3 +1,7 @@
+/* Desktop CSS */
+
+@media (min-width: 480px) {
+
 @import url('https://fonts.cdnfonts.com/css/norwester');
 
 .layout {
@@ -40,4 +44,95 @@
   /*position buttons simultaneously*/
   padding-top: 10vh;
   padding-left: 32vw;
+}
+
+/* New button class */
+
+.logButton {
+  width: 16vw;
+  height: 3.75vw;
+  font-weight: bold;
+  font-size: 1.2vw;
+  size: large;
+}
+
+}
+
+/* Mobile CSS */
+
+@media (max-width: 480px) {
+
+  .navbar {
+    display: none;
+  }
+
+  .layout {
+  padding: 0vh 0vw 0vw 0vw;
+}
+
+.content {
+  /*holds everything on the page including the infopanels*/
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.row {
+  /*holds only the logo, title, and login buttons*/
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+  max-width: 480px;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+}
+
+.orangetext {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+  width: 100%;
+  height: 60%;
+  padding-top: 7.5vh;
+}
+
+.buttonspace {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.logButton {
+  width: 70vw;
+  height: 7.5vh;
+  font-weight: bold;
+  font-size: 4vw;
+}
+
+p {
+  display: none;
+}
+
+header {
+  display: none;
+}
+
+footer {
+  display: none;
+}
+  
 }

--- a/src/components/pages/Splash/index.tsx
+++ b/src/components/pages/Splash/index.tsx
@@ -29,8 +29,8 @@ export default function Splash() {
                 <Space size="large" className={styles.buttonspace}>
                   <Button
                     shape="round"
-                    size="large"
-                    style={{ width: '16vw', height: '3.75vw', fontWeight: 'bold', fontSize: '1.2vw' }}
+                    /* Added class for button & removed size attr since edits in html supersede all CSS */
+                    className={styles.logButton}
                     id="signup-btn"
                     onClick={() => {
                       navigate('/register');
@@ -40,8 +40,8 @@ export default function Splash() {
                   </Button>
                   <Button
                     shape="round"
-                    size="large"
-                    style={{ width: '16vw', height: '3.75vw', fontWeight: 'bold', fontSize: '1.2vw' }}
+                    /* Added class for button & removed size attr since edits in html supersede all CSS */
+                    className={styles.logButton}
                     id="login-btn"
                     onClick={() => {
                       navigate('/login');


### PR DESCRIPTION
-added media queries to infopanels 1, 2 & 3 for desktop and mobile
-added media queries to splash.module.css for desktop and mobile
-removed inline styling on login & signup buttons, and added className={styles.logButton} for both.