### PR TITLE
fixed account page layout. optimized for mobile and 1366x768

### DIFF
--- a/src/components/DashRow/DashRow.module.css
+++ b/src/components/DashRow/DashRow.module.css
@@ -1,3 +1,5 @@
+@media (min-width: 1920px) {
+
 .row-container {
   width: 50%;
   max-width: 1400px;
@@ -38,10 +40,90 @@
   box-shadow: 6px 3px black;
 }
 
+}
+
+/* this is super fucked but it works */
+
+@media (min-width: 1366px) and (max-width: 1919px) {
+
+  .row-container {
+  width: 75%;
+  max-width: 1400px;
+  text-align: center;
+  align-items: center;
+  align-self: center;
+  padding: 0 2rem 0 4rem;
+  justify-content: center;
+  margin: 1.25vw;
+  margin-left: 25%;
+}
+
+.download-button {
+  font-size: 1.5vw;
+  margin-right: 1vw;
+}
+
+.text-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  margin-left: 2vw;
+}
+
+.title {
+  cursor: pointer;
+  margin-left: 3vw;
+  align-self: flex-start;
+  font-size: clamp(15px, 1vw, 20px);
+}
+
+.info-text {
+  margin-left: 3vw;
+  margin-top: -1vh;
+  align-self: flex-start;
+  font-size: clamp(13px, 0.8vw, 18px);
+}
+.artwork {
+  box-shadow: 6px 3px black;
+}
+
+}
+
+/* mobile css */
+
 @media (max-width: 480px) {
   .row-container {
     padding: 1vh;
     width: 100vw;
     justify-content: space-between;
   }
+
+.download-button {
+  font-size: 1.5vw;
+  margin-right: 1vw;
+}
+
+.text-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  margin-left: 2vw;
+}
+
+.title {
+  cursor: pointer;
+  margin-left: 3vw;
+  align-self: flex-start;
+  font-size: clamp(15px, 1vw, 20px);
+}
+
+.info-text {
+  margin-left: 3vw;
+  margin-top: -1vh;
+  align-self: flex-start;
+  font-size: clamp(13px, 0.8vw, 18px);
+}
+.artwork {
+  box-shadow: 6px 3px black;
+}
 }

--- a/src/components/pages/Account/Account.module.css
+++ b/src/components/pages/Account/Account.module.css
@@ -1,3 +1,12 @@
+@media (min-width: 480px) {
+
+.Content {
+  display: flex;
+  justify-content: center;
+  margin-top: 10vh;
+  width: 100%;
+}
+
 .heading {
   padding-left: min(30vw, 20px);
   align-self: flex-start;
@@ -26,4 +35,49 @@
 .following-avatar {
   width: clamp(20px, 10vw, 300px);
   height: clamp(20px, 10vw, 300px);
+}
+
+}
+
+@media (max-width: 480px) {
+
+  .Content {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    margin-left: 19vw;
+}
+
+  .heading {
+  padding-left: min(30vw, 20px);
+  align-self: flex-start;
+  font-size: clamp(20px, 2vw, 30px);
+}
+
+.chartcont {
+  width: 100%;
+  height: 10vh;
+}
+
+.divider {
+  color: black;
+  width: 10vw;
+  margin-bottom: 200px;
+}
+
+.beats-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-items: center;
+  justify-content: center;
+}
+
+.following-avatar {
+  width: clamp(20px, 10vw, 300px);
+  height: clamp(20px, 10vw, 300px);
+  margin-bottom: 20px;
+}
+
 }

--- a/src/components/pages/Account/index.tsx
+++ b/src/components/pages/Account/index.tsx
@@ -1,3 +1,4 @@
+import { Content } from 'antd/lib/layout/layout';
 import { useState, useEffect } from 'react';
 import { Column } from '@ant-design/plots';
 import { Row, Avatar, Button } from 'antd';
@@ -95,6 +96,7 @@ export default function AccountPage() {
   };
 
   return (
+    <Content className={styles.Content}>
     <div style={{ width: '80%', marginBottom: '20px' }}>
       <h1 className={`${styles.heading} heading`}>My Account 🔨</h1>
       <p>Credits: {creditsBalance}</p>
@@ -154,5 +156,6 @@ export default function AccountPage() {
         </Row>
       </div>
     </div>
+    </Content>
   );
 }


### PR DESCRIPTION
Really fucked solution but it works.

-Fixed account page being cut off at top of screen.
-Optimized for mobile.
-Optimized for 1366x768, dashrow is still not fully centered on account page for 1366x768 but will work on it more.